### PR TITLE
Serializing objects with undefined or null values

### DIFF
--- a/baseSerializer.js
+++ b/baseSerializer.js
@@ -28,6 +28,10 @@ export default (err, serializeError) => {
     }
 
     const value = err[key];
+    if(value === null || value === undefined) {
+      continue;
+    }
+
     if(hasOwnProperty.call(value, seen)) {
       continue;
     }

--- a/baseSerializer.js
+++ b/baseSerializer.js
@@ -32,7 +32,7 @@ export default (err, serializeError) => {
       continue;
     }
 
-    if(hasOwnProperty.call(value, seen)) {
+    if(typeof value === 'object' && hasOwnProperty.call(value, seen)) {
       continue;
     }
 

--- a/test/basic-serialization.js
+++ b/test/basic-serialization.js
@@ -23,3 +23,35 @@ test('serializes custom keys added to errors with just the base serializer', asy
 
   t.equal(serialized.statistics, 2);
 });
+
+[ undefined, null ].forEach((value) => {
+  test(`serializes ${value} fields out of existence`, async (t) => {
+    const foo = {'foo': value};
+
+    const serializeError = await createSerializer({ include: [] });
+    const serialized = serializeError(foo);
+
+    t.ok(serialized);
+    t.equal(serialized.foo, undefined);
+  });
+});
+
+test('serializes falsy 0 value correctly', async (t) => {
+  const foo = {'foo': 0};
+
+  const serializeError = await createSerializer({ include: [] });
+  const serialized = serializeError(foo);
+
+  t.ok(serialized);
+  t.equal(serialized.foo, 0);
+});
+
+test('serializes falsy empty string value correctly', async (t) => {
+  const foo = {'foo': 0};
+
+  const serializeError = await createSerializer({ include: [] });
+  const serialized = serializeError(foo);
+
+  t.ok(serialized);
+  t.same(serialized.foo, '');
+});


### PR DESCRIPTION
These values crashed the serializer. This PR fixes #1.