### PR TITLE
Synchronous base serializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,26 @@ app.use((req, res, next) => {
 
 Notice that in both cases the special key `err` is what you need to put errors in to have them serialized using this serializer.
 
+### Synchronous loading
+
+If you do not want to use the asynchronous constructor (`createErrorSerializer`) you can instead choose to import just the base serializer using the `serialize-every-error/base` export. 
+
+The base serializer only includes a simple serializer that works for *most errors* but without the added nice error serialization for certain errors.
+
+The base serializer can be plugged in to e.g. pino in an express app like this (see context above):
+
+```js
+import serializeError from 'serialize-every-error/base';
+
+app.use(pino({
+    serializers: {
+        ...pino.stdSerializers,
+        err: serializeError,
+    },
+    wrapSerializers: false,
+}));
+```
+
 Reference
 ---------
 

--- a/exports/base.js
+++ b/exports/base.js
@@ -1,0 +1,4 @@
+import baseSerializer from '../baseSerializer.js';
+
+const recursiveBaseSerializer = (err) => baseSerializer(err, recursiveBaseSerializer);
+export default recursiveBaseSerializer;

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
   "directories": {
     "test": "test"
   },
+  "exports": {
+    "./base": "./exports/base.js"
+  },
   "dependencies": {},
   "repository": {
     "type": "git",

--- a/test/synchronous-base-serializer.js
+++ b/test/synchronous-base-serializer.js
@@ -1,0 +1,14 @@
+import { test } from 'tap';
+import serializeError from '../exports/base.js';
+
+test('synchronously importing the base serializer works', async (t) => {
+  const baz = new Error('baz');
+  const bar = new Error('bar', { cause: baz });
+  const foo = new Error('foo', { cause: bar });
+
+  const serialized = serializeError(foo);
+
+  t.equal(serialized.message, 'foo');
+  t.equal(serialized.cause.message, 'bar');
+  t.equal(serialized.cause.cause.message, 'baz');
+});


### PR DESCRIPTION
This PR adds a synchronous export `/base` which loads just the base serializer, but does so synchronously. Addresses some of #4.